### PR TITLE
fix: treat empty strings as undefined env vars

### DIFF
--- a/config/env.config.js
+++ b/config/env.config.js
@@ -3,6 +3,7 @@ import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
 export const env = createEnv({
+	emptyStringAsUndefined: true,
 	shared: {
 		NODE_ENV: z.enum(["development", "production", "test"]).default("production"),
 	},


### PR DESCRIPTION
this treats empty strings like `undefined` in environment variable validation.

TODO: consider setting `ENV_VALIDATION=disabled` in ci/cd, to avoid having to pass secrets to docker build context.