### PR TITLE
fix: add limit search param to zotero request

### DIFF
--- a/lib/zotero.ts
+++ b/lib/zotero.ts
@@ -89,6 +89,8 @@ export async function getCollectionItems(id: string) {
 			itemType: "-note",
 			/** Valid options are: "bib", "citation", "data". */
 			include: ["bib", "data"].join(","),
+			limit: 100,
+			sort: "date",
 		}),
 	});
 


### PR DESCRIPTION
this adds a `limit=100` url search param when requesting publications from zotero (default is 25).

as a follow-up we should refactor this and (i) propertly read the pagination info returned from the zotero api via `Link` header [sic], and (ii) format citations outselves because (i.e. drop the `include=bib` param) because this slow down the zotero api response times dramatically.