### PR TITLE
docs: clarify label for dariah-commissioned-events field

### DIFF
--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
@@ -250,7 +250,7 @@ async function DashboardCountryReportEditStepPageContent(
 						<p>
 							These are big, international events that are commissioned by DARIAH and serve to
 							fulfill a strategic interest. Examples include the Annual Event or the DARIAH
-							Innovation Forum. Do not fill out anyting here, DARIAH staff will fill this section
+							Innovation Forum. Do not fill out anything here, DARIAH staff will fill this section
 							out for you, if relevant.
 						</p>
 					</FormDescription>

--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
@@ -250,7 +250,8 @@ async function DashboardCountryReportEditStepPageContent(
 						<p>
 							These are big, international events that are commissioned by DARIAH and serve to
 							fulfill a strategic interest. Examples include the Annual Event or the DARIAH
-							Innovation Forum. DARIAH staff will fill this section out for you, if relevant.
+							Innovation Forum. Do not fill out anyting here, DARIAH staff will fill this section
+							out for you, if relevant.
 						</p>
 					</FormDescription>
 

--- a/components/forms/event-report-form-content.tsx
+++ b/components/forms/event-report-form-content.tsx
@@ -55,7 +55,7 @@ export function EventReportFormContent(props: EventReportFormContentProps): Reac
 						? `Previous year: ${previousEventReport.dariahCommissionedEvent}.`
 						: undefined
 				}
-				label="DARIAH commissioned event"
+				label="Title of DARIAH commissioned event"
 				name="eventReport.dariahCommissionedEvent"
 			/>
 

--- a/components/forms/event-report-form-content.tsx
+++ b/components/forms/event-report-form-content.tsx
@@ -55,6 +55,7 @@ export function EventReportFormContent(props: EventReportFormContentProps): Reac
 						? `Previous year: ${previousEventReport.dariahCommissionedEvent}.`
 						: undefined
 				}
+				isReadOnly={true}
 				label="Title of DARIAH commissioned event"
 				name="eventReport.dariahCommissionedEvent"
 			/>


### PR DESCRIPTION
x-ref #192

this changes the form-field label in the event-report form from "DARIAH commissioned event" to "Title of DARIAH commissioned event" so it is a bit clearer that this field accepts a string, not a number.