### PR TITLE
fix: use pagination info from link header in zotero api response, and format csljson

### DIFF
--- a/components/admin/statistics-content.tsx
+++ b/components/admin/statistics-content.tsx
@@ -154,12 +154,12 @@ async function PublicationsCount(props: PublicationsCountProps) {
 		const publications = items.filter((item) => {
 			/**
 			 * Filter publications by publication year client-side, because the zotero api does
-			 * not allow that. Note that the `parsedDate` field is just a string field, so parsing
-			 * as a ISO8601 date is not guaranteed to work.
+			 * not allow that. Note that both the `data.date` and `meta.parsedDate` fields are just
+			 * string fields, so parsing as a ISO8601 date is not guaranteed to work.
 			 */
 			try {
-				const date = new Date(item.data.date);
-				if (date.getUTCFullYear() === year) return true;
+				// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+				if (Number(item.issued?.["date-parts"]?.[0]?.[0]) === year) return true;
 				return false;
 			} catch {
 				return false;

--- a/components/forms/publications-form-content.tsx
+++ b/components/forms/publications-form-content.tsx
@@ -14,21 +14,15 @@ import { createKey } from "@/lib/create-key";
 import type { ReportCommentsSchema } from "@/lib/schemas/report";
 
 interface PublicationsFormContentProps {
+	bibliography: string;
 	comments: ReportCommentsSchema["publications"];
-	publications: Array<{
-		id: string;
-		// title: string;
-		// kind: string;
-		// url?: string;
-		// creators: string;
-		citation: string;
-	}>;
 	reportId: Report["id"];
+	total: number;
 	year: number;
 }
 
 export function PublicationsFormContent(props: PublicationsFormContentProps): ReactNode {
-	const { comments, publications, reportId, year } = props;
+	const { bibliography, comments, reportId, total, year } = props;
 
 	const [formState, formAction] = useFormState(updatePublicationsAction, undefined);
 
@@ -40,23 +34,8 @@ export function PublicationsFormContent(props: PublicationsFormContentProps): Re
 		>
 			<input name="reportId" type="hidden" value={reportId} />
 
-			{publications.length > 0 ? (
-				<ul
-					className="grid max-w-screen-md gap-y-2 text-sm leading-relaxed text-neutral-700 dark:text-neutral-300"
-					role="list"
-				>
-					{publications.map((publication) => {
-						const { id, citation } = publication;
-
-						return (
-							<li key={id}>
-								<article>
-									<span dangerouslySetInnerHTML={{ __html: citation }} />
-								</article>
-							</li>
-						);
-					})}
-				</ul>
+			{total > 0 ? (
+				<div dangerouslySetInnerHTML={{ __html: bibliography }} />
 			) : (
 				<div className="grid place-items-center py-6 text-sm leading-relaxed text-neutral-700 dark:text-neutral-300">
 					No entries found for {year} in your zotero collection.

--- a/components/forms/publications-form.tsx
+++ b/components/forms/publications-form.tsx
@@ -15,13 +15,14 @@ export async function PublicationsForm(props: PublicationsFormProps) {
 	const { comments, countryCode, reportId, year } = props;
 
 	// FIXME: handle fetch errors
-	const publications = await getPublications({ countryCode, year });
+	const { bibliography, items } = await getPublications({ countryCode, year });
 
 	return (
 		<PublicationsFormContent
+			bibliography={bibliography}
 			comments={comments?.publications}
-			publications={publications}
 			reportId={reportId}
+			total={items.length}
 			year={year}
 		/>
 	);

--- a/components/forms/report-summary.tsx
+++ b/components/forms/report-summary.tsx
@@ -113,15 +113,8 @@ export async function ReportSummary(props: ReportSummaryProps) {
 			}),
 		},
 		publications: {
-			count: publications.length,
-			items: publications.map((p) => {
-				return {
-					creators: p.creators.join(", "),
-					title: p.title,
-					kind: p.kind,
-					url: p.url ?? null,
-				};
-			}),
+			count: publications.items.length,
+			items: publications.items,
 		},
 		services: {
 			count: services.length,

--- a/lib/create-bibliography.ts
+++ b/lib/create-bibliography.ts
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import "@citation-js/plugin-csl";
+
+// @ts-expect-error Missing type declaration.
+import { Cite } from "@citation-js/core";
+
+export function createBibliography(publications: Array<{ id: string }>): string {
+	const cite = new Cite(publications);
+
+	const bibliography = cite.format("bibliography", {
+		format: "html",
+		template: "apa",
+	});
+
+	return bibliography as string;
+}

--- a/lib/parse-link-header.ts
+++ b/lib/parse-link-header.ts
@@ -1,0 +1,24 @@
+export function parseLinkHeader(header: string | null): Record<string, string> {
+	const links: Record<string, string> = {};
+
+	if (header == null) {
+		return links;
+	}
+
+	const parts = header.split(",");
+
+	parts.forEach((part) => {
+		const section = part.split(";");
+		if (section.length < 2) return;
+
+		const url = section[0]!.trim().slice(1, -1);
+
+		const relMatch = /rel="(.+)"/.exec(section[1]!.trim());
+		if (relMatch) {
+			const rel = relMatch[1]!;
+			links[rel] = url;
+		}
+	});
+
+	return links;
+}

--- a/lib/zotero.ts
+++ b/lib/zotero.ts
@@ -99,17 +99,14 @@ export async function getCollectionItems(id: string) {
 	// let total: number;
 
 	do {
-		const response = (await request(url, {
-			headers,
-			responseType: "raw",
-		})) as Response;
+		const response = await fetch(url, { headers, cache: "force-cache" });
 
 		data.push(...((await response.json()) as Array<ZoteroItem>));
 
 		/**
 		 * Zotero returns pagination information in link header.
 		 *
-		 * @see https://www.zotero.org/support/dev/web_api/v3/basics?parameters_for_format_bib_includecontent_bib_includecontent_citation#sorting_and_pagination
+		 * @see https://www.zotero.org/support/dev/web_api/v3/basics#sorting_and_pagination
 		 */
 		const links = parseLinkHeader(response.headers.get("link"));
 
@@ -162,6 +159,7 @@ export async function getPublications(params: GetPublicationsParams) {
 					if (isNonEmptyString(creator.name)) return creator.name;
 					return [creator.firstName, creator.lastName].filter(isNonEmptyString).join(" ");
 				}),
+				/** Available because of `?include=bib`. */
 				citation: item.bib,
 			};
 		})

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
 		"@acdh-oeaw/lib": "^0.1.12",
 		"@acdh-oeaw/validate-env": "^0.0.3",
 		"@auth/prisma-adapter": "^2.7.0",
+		"@citation-js/core": "^0.7.18",
+		"@citation-js/plugin-csl": "^0.7.18",
 		"@internationalized/date": "^3.5.6",
 		"@keystatic/core": "^0.5.37",
 		"@keystatic/next": "^5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,12 @@ importers:
       '@auth/prisma-adapter':
         specifier: ^2.7.0
         version: 2.7.0(@prisma/client@5.20.0(prisma@5.20.0))(nodemailer@6.9.15)
+      '@citation-js/core':
+        specifier: ^0.7.18
+        version: 0.7.18
+      '@citation-js/plugin-csl':
+        specifier: ^0.7.18
+        version: 0.7.18(@citation-js/core@0.7.18)
       '@internationalized/date':
         specifier: ^3.5.6
         version: 3.5.6
@@ -518,6 +524,24 @@ packages:
 
   '@braintree/sanitize-url@6.0.4':
     resolution: {integrity: sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==}
+
+  '@citation-js/core@0.7.18':
+    resolution: {integrity: sha512-EjLuZWA5156dIFGdF7OnyPyWFBW43B8Ckje6Sn/W2RFxHDu0oACvW4/6TNgWT80jhEA4bVFm7ahrZe9MJ2B2UQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@citation-js/date@0.5.1':
+    resolution: {integrity: sha512-1iDKAZ4ie48PVhovsOXQ+C6o55dWJloXqtznnnKy6CltJBQLIuLLuUqa8zlIvma0ZigjVjgDUhnVaNU1MErtZw==}
+    engines: {node: '>=10.0.0'}
+
+  '@citation-js/name@0.4.2':
+    resolution: {integrity: sha512-brSPsjs2fOVzSnARLKu0qncn6suWjHVQtrqSUrnqyaRH95r/Ad4wPF5EsoWr+Dx8HzkCGb/ogmoAzfCsqlTwTQ==}
+    engines: {node: '>=6'}
+
+  '@citation-js/plugin-csl@0.7.18':
+    resolution: {integrity: sha512-cJcOdEZurmtIxNj0d4cOERHpVQJB/mN3YPSDNqfI/xTFRN3bWDpFAsaqubPtMO2ZPpoDS+ZGIP1kggbwCfMmlA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@citation-js/core': ^0.7.0
 
   '@commitlint/cli@19.5.0':
     resolution: {integrity: sha512-gaGqSliGwB86MDmAAKAtV9SV1SHdmN8pnGq4EJU4+hLisQ7IFfx4jvU4s+pk6tl0+9bv6yT+CaZkufOinkSJIQ==}
@@ -2867,6 +2891,9 @@ packages:
   balanced-match@2.0.0:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   bcrypt@5.1.1:
     resolution: {integrity: sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==}
     engines: {node: '>= 10.0.0'}
@@ -2892,6 +2919,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -2977,6 +3007,9 @@ packages:
   ci-info@4.0.0:
     resolution: {integrity: sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==}
     engines: {node: '>=8'}
+
+  citeproc@2.4.63:
+    resolution: {integrity: sha512-68F95Bp4UbgZU/DBUGQn0qV3HDZLCdI9+Bb2ByrTaNJDL5VEm9LqaiNaxljsvoaExSLEXe1/r6n2Z06SCzW3/Q==}
 
   cjs-module-lexer@1.4.1:
     resolution: {integrity: sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==}
@@ -3634,6 +3667,9 @@ packages:
       picomatch:
         optional: true
 
+  fetch-ponyfill@7.1.0:
+    resolution: {integrity: sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==}
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
@@ -3936,6 +3972,9 @@ packages:
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4717,6 +4756,15 @@ packages:
 
   node-addon-api@5.1.0:
     resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
+
+  node-fetch@2.6.13:
+    resolution: {integrity: sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -5636,6 +5684,10 @@ packages:
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
+  sync-fetch@0.4.5:
+    resolution: {integrity: sha512-esiWJ7ixSKGpd9DJPBTC4ckChqdOjIwJfYhVHkcQ2Gnm41323p1TRmEI+esTQ9ppD+b5opps2OTEGTCGX5kF+g==}
+    engines: {node: '>=14'}
+
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
 
@@ -6498,6 +6550,25 @@ snapshots:
       to-fast-properties: 2.0.0
 
   '@braintree/sanitize-url@6.0.4': {}
+
+  '@citation-js/core@0.7.18':
+    dependencies:
+      '@citation-js/date': 0.5.1
+      '@citation-js/name': 0.4.2
+      fetch-ponyfill: 7.1.0
+      sync-fetch: 0.4.5
+    transitivePeerDependencies:
+      - encoding
+
+  '@citation-js/date@0.5.1': {}
+
+  '@citation-js/name@0.4.2': {}
+
+  '@citation-js/plugin-csl@0.7.18(@citation-js/core@0.7.18)':
+    dependencies:
+      '@citation-js/core': 0.7.18
+      '@citation-js/date': 0.5.1
+      citeproc: 2.4.63
 
   '@commitlint/cli@19.5.0(@types/node@22.7.5)(typescript@5.6.3)':
     dependencies:
@@ -9619,6 +9690,8 @@ snapshots:
 
   balanced-match@2.0.0: {}
 
+  base64-js@1.5.1: {}
+
   bcrypt@5.1.1:
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.11
@@ -9650,6 +9723,11 @@ snapshots:
       update-browserslist-db: 1.1.1(browserslist@4.24.0)
 
   buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   busboy@1.6.0:
     dependencies:
@@ -9730,6 +9808,8 @@ snapshots:
   ci-info@3.9.0: {}
 
   ci-info@4.0.0: {}
+
+  citeproc@2.4.63: {}
 
   cjs-module-lexer@1.4.1: {}
 
@@ -10534,6 +10614,12 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fetch-ponyfill@7.1.0:
+    dependencies:
+      node-fetch: 2.6.13
+    transitivePeerDependencies:
+      - encoding
+
   fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
@@ -10891,6 +10977,8 @@ snapshots:
   idb-keyval@6.2.1: {}
 
   idb@7.1.1: {}
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -11892,6 +11980,10 @@ snapshots:
       '@types/nlcst': 2.0.3
 
   node-addon-api@5.1.0: {}
+
+  node-fetch@2.6.13:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-fetch@2.7.0:
     dependencies:
@@ -13067,6 +13159,13 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-tags@1.0.0: {}
+
+  sync-fetch@0.4.5:
+    dependencies:
+      buffer: 5.7.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   tabbable@6.2.0: {}
 


### PR DESCRIPTION
this parses pagination info from the `Link` header returned with zotero api responses, so we can correctly fetch all items in a collection.

unfortunately, the zotero api is dead slow, so this is resulting in even more `TimeoutError`s than before.

one approach would be to format citations ourselves (with `citation-js`) instead of requesting formatted citations via `?include=bib`, which seems to affect query perf quite dramatically. it would also solve the incorrect sorting of entries by the zotero api, which does not correctly sort accented characters (i.e. É before A).

this is what this pr does: request data in csl-json format from zotero, and use citation-js to format a bibliography.

closes #198
