### PR TITLE
feat: wrap zotero api calls with error boundary

### DIFF
--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
@@ -7,6 +7,7 @@ import { type ReactNode, Suspense } from "react";
 
 import { AppLink } from "@/components/app-link";
 import { Delay } from "@/components/delay";
+import { ErrorBoundary } from "@/components/error-boundary";
 import { FormDescription } from "@/components/form-description";
 import { FormTitle } from "@/components/form-title";
 import { ConfirmationForm } from "@/components/forms/confirmation-form";
@@ -399,14 +400,16 @@ async function DashboardCountryReportEditStepPageContent(
 						</p>
 					</FormDescription>
 
-					<FormPlaceholder>
-						<PublicationsForm
-							comments={comments}
-							countryCode={code}
-							reportId={report.id}
-							year={year}
-						/>
-					</FormPlaceholder>
+					<ErrorBoundary fallback={<div>Failed to fetch publications from zotero.</div>}>
+						<FormPlaceholder>
+							<PublicationsForm
+								comments={comments}
+								countryCode={code}
+								reportId={report.id}
+								year={year}
+							/>
+						</FormPlaceholder>
+					</ErrorBoundary>
 
 					<Navigation code={code} next="project-funding-leverage" previous="software" year={year} />
 				</section>

--- a/components/admin/statistics-content.tsx
+++ b/components/admin/statistics-content.tsx
@@ -1,6 +1,7 @@
 import { useFormatter } from "next-intl";
 import { Suspense } from "react";
 
+import { ErrorBoundary } from "@/components/error-boundary";
 import { MainContent } from "@/components/main-content";
 import { getCollectionItems, getCollectionsByCountryCode } from "@/lib/zotero";
 
@@ -124,9 +125,11 @@ export function AdminStatisticsContent(props: AdminStatisticsContentProps) {
 					</dd>
 				</div>
 
-				<Suspense fallback={<div>Fetching publications from zotero...</div>}>
-					<PublicationsCount year={year} />
-				</Suspense>
+				<ErrorBoundary fallback={<div>Failed to fetch publications from zotero.</div>}>
+					<Suspense fallback={<div>Fetching publications from zotero...</div>}>
+						<PublicationsCount year={year} />
+					</Suspense>
+				</ErrorBoundary>
 
 				<div>
 					<dt>Project funding leverage</dt>

--- a/components/error-boundary.tsx
+++ b/components/error-boundary.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { assert } from "@acdh-oeaw/lib";
+import { Component, createContext, type ErrorInfo, type ReactNode, use } from "react";
+
+interface ErrorBoundaryContextValue {
+	error: Error;
+	reset: () => void;
+}
+
+const ErrorBoundaryContext = createContext<ErrorBoundaryContextValue | null>(null);
+
+export function useErrorBoundary() {
+	const value = use(ErrorBoundaryContext);
+
+	assert(value != null, "`useErrorBoundary` must be used within an `ErrorBoundary` component.");
+
+	return value;
+}
+
+interface ErrorBoundaryProps {
+	children: ReactNode;
+	fallback: ReactNode;
+	onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+type ErrorBoundaryState =
+	| {
+			status: "default";
+			error: null;
+	  }
+	| {
+			status: "error";
+			error: Error;
+	  };
+
+const initialState: ErrorBoundaryState = {
+	status: "default",
+	error: null,
+};
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+	constructor(props: ErrorBoundaryProps) {
+		super(props);
+
+		this.state = initialState;
+
+		this.reset = this.reset.bind(this);
+	}
+
+	static getDerivedStateFromError(error: unknown) {
+		return {
+			status: "error",
+			error: error instanceof Error ? error : new Error(`Error: ${String(error)}`),
+		};
+	}
+
+	componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+		this.props.onError?.(error, errorInfo);
+	}
+
+	reset() {
+		this.setState(initialState);
+	}
+
+	render() {
+		if (this.state.status === "error") {
+			return (
+				// eslint-disable-next-line @typescript-eslint/unbound-method
+				<ErrorBoundaryContext.Provider value={{ error: this.state.error, reset: this.reset }}>
+					{this.props.fallback}
+				</ErrorBoundaryContext.Provider>
+			);
+		}
+
+		return this.props.children;
+	}
+}

--- a/lib/zotero.ts
+++ b/lib/zotero.ts
@@ -86,7 +86,6 @@ export async function getCollectionItems(id: string) {
 	do {
 		const response = await fetch(url, {
 			headers,
-			cache: "force-cache",
 			next: { revalidate: 60 * 5 /** 5 min */ },
 		});
 		const { items } = (await response.json()) as { items: Array<ZoteroItem> };

--- a/lib/zotero.ts
+++ b/lib/zotero.ts
@@ -1,4 +1,4 @@
-import { createUrl, createUrlSearchParams, keyByToMap, request } from "@acdh-oeaw/lib";
+import { createUrl, createUrlSearchParams, keyByToMap } from "@acdh-oeaw/lib";
 
 import { groupId } from "@/config/zotero.config";
 import { createBibliography } from "@/lib/create-bibliography";
@@ -57,10 +57,16 @@ export async function getCollectionsByCountryCode() {
 		}),
 	});
 
-	const collections = (await request(url, {
+	const response = await fetch(url, {
 		headers,
-		responseType: "json",
-	})) as Array<ZoteroCollection>;
+		next: { revalidate: 60 * 60 /** 60 min */ },
+	});
+
+	if (!response.ok) {
+		throw new Error("Failed to fetch collections from Zotero API.");
+	}
+
+	const collections = (await response.json()) as Array<ZoteroCollection>;
 
 	const collectionsByCountryCode = keyByToMap(collections, (collection) => {
 		return collection.data.name.toLowerCase();
@@ -88,6 +94,11 @@ export async function getCollectionItems(id: string) {
 			headers,
 			next: { revalidate: 60 * 5 /** 5 min */ },
 		});
+
+		if (!response.ok) {
+			throw new Error("Failed to fetch collection items from Zotero API.");
+		}
+
 		const { items } = (await response.json()) as { items: Array<ZoteroItem> };
 
 		data.push(...items);


### PR DESCRIPTION
this wraps UI which displays publications fetched from the zotero api, so we don't display a full error-page when the api request fails.

also adds cache for the api request for collections metadata, with a TTL of 60 minutes.