### PR TITLE
build: apply migrations in docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,10 +82,18 @@ FROM node:22-alpine AS serve
 # @see https://github.com/nodejs/docker-node/issues/2175
 RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
 
+RUN corepack enable
+
 RUN mkdir /app && chown -R node:node /app
 WORKDIR /app
 
 USER node
+
+COPY --chown=node:node ./entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+
+COPY --chown=node:node ./prisma/schema.prisma ./prisma/schema.prisma
+COPY --chown=node:node ./prisma/migrations ./prisma/migrations
 
 COPY --from=build --chown=node:node /app/next.config.js ./
 COPY --from=build --chown=node:node /app/public ./public
@@ -100,4 +108,5 @@ ENV NODE_ENV=production
 
 EXPOSE 3000
 
+ENTRYPOINT [ "./entrypoint.sh" ]
 CMD ["node", "server.js"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -e
+
+echo "⏳ Waiting for database to be ready..."
+
+until nc -z -v -w30 localhost 5432
+do
+  echo "⏳ Waiting for DB connection..."
+  sleep 2
+done
+
+echo "✅ Database is up! Running migrations..."
+
+pnpx prisma migrate deploy
+
+echo "🚀 Starting app..."
+
+exec "$@"


### PR DESCRIPTION
this adds an entrypoint to our dockerfile which applies database migrations before app start/up.

FOLLOW-UP:
- [ ] avoid installing prisma cli on every entrypoint invocation