### PR TITLE
fix: use useEffectEvent from react-aria

### DIFF
--- a/components/admin/use-filtered-items.ts
+++ b/components/admin/use-filtered-items.ts
@@ -1,9 +1,5 @@
-import {
-	experimental_useEffectEvent as useEffectEvent,
-	useCallback,
-	useMemo,
-	useState,
-} from "react";
+import { useEffectEvent } from "@react-aria/utils";
+import { useCallback, useMemo, useState } from "react";
 
 export const EMPTY_FILTER = "_all_";
 


### PR DESCRIPTION
this uses react-aria's `useEffectEvent` implementation instead of the experimental one from `react` itself, which apparently is not allowed to be called inside of `useMemo` (currently?).