### PR TITLE
fix: ensure body is not scrollable when popover is open

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -187,7 +187,6 @@
 	}
 
 	body {
-		overflow-y: auto;
 		block-size: 100%;
 	}
 


### PR DESCRIPTION
closes #277
