### PR TITLE
fix: add workaround for datefield validation

### DIFF
--- a/components/ui/date-field.tsx
+++ b/components/ui/date-field.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CalendarDate } from "@internationalized/date";
 import {
 	composeRenderProps,
 	DateField as AriaDateField,
@@ -8,6 +9,9 @@ import {
 } from "react-aria-components";
 
 import { type VariantProps, variants } from "@/lib/styles";
+
+/** @see https://github.com/adobe/react-spectrum/issues/3256 */
+const defaultPlaceholderValue = new CalendarDate(2024, 1, 1);
 
 export type { AriaDateValue as DateValue };
 
@@ -26,6 +30,7 @@ export function DateField<T extends AriaDateValue>(props: DateFieldProps<T>) {
 
 	return (
 		<AriaDateField<T>
+			placeholderValue={defaultPlaceholderValue as T}
 			{...rest}
 			className={composeRenderProps(className, (className, renderProps) => {
 				return dateFieldStyles({ ...renderProps, className });


### PR DESCRIPTION
the date field from `react-aria-components` currently validates each date segment immediately when numbers are entered. internally, it always requires a valid date, and defaults to the current date. therefore, when we are currently in a month with 30 days, and a user starts entering a date in the date field which starts with 31, it will not allow that.

the current workaround, until this is fixed upstream, is to explicitly set a placeholder date, which defaults to 2024-01-01 (january has 31 days, and 2024 was a leap year).

closes #283
